### PR TITLE
fix: aurora migration fail for rails 5

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -210,8 +210,8 @@ module Lhm
     end
 
     def destination_create
-      original    = %{CREATE TABLE `#{ @origin.name }`}
-      replacement = %{CREATE TABLE `#{ @origin.destination_name }`}
+      original    = %r{CREATE TABLE ("|`)#{ @origin.name }("|`)}
+      replacement = %{CREATE TABLE \\1#{ @origin.destination_name }\\2}
       stmt = @origin.ddl.gsub(original, replacement)
       @connection.execute(tagged(stmt))
 


### PR DESCRIPTION
By looking at the failing migration logs for `rails 5`, it was found that the `ddl` query contains doublequotes(`"`) around the table name and that is why the `gsub` was not substituting the table name and the same table was being created again which causes the error.
As this was not happening when using `mysql` and was only happening when we try to deploy using `Aurora DB`, both the `gsub` conditions are kept so that it will work on all other databases as well.

```bash
I, [2023-10-06T13:06:48.698021 #71110]  INFO -- : About to create destination table
I, [2023-10-06T13:06:48.698053 #71110]  INFO -- : Original: CREATE TABLE `clients`
I, [2023-10-06T13:06:48.698085 #71110]  INFO -- : Replacement: CREATE TABLE `lhmn_clients`
I, [2023-10-06T13:06:48.698118 #71110]  INFO -- : DDL: CREATE TABLE "clients" (
  "id" int(11) NOT NULL AUTO_INCREMENT,
  "account_type" int(11) NOT NULL DEFAULT '1',
.
.
.
```
